### PR TITLE
Optimize Gunicorn workers for better performance (free)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn tenantguard.wsgi:application --bind 0.0.0.0:8000 --workers 3 --timeout 120
+web: gunicorn tenantguard.wsgi:application --bind 0.0.0.0:8000 --workers 4 --timeout 120 --max-requests 1000 --max-requests-jitter 50


### PR DESCRIPTION
- Increase workers from 3 to 4 for better concurrency
- Add --max-requests 1000 to recycle workers and prevent memory leaks
- Add --max-requests-jitter 50 to randomize worker recycling

These are free optimizations that improve performance without requiring additional AWS resources or costs.