### PR TITLE
Fix static files issue: Add collectstatic to post-deploy hook

### DIFF
--- a/.platform/hooks/postdeploy/01_setup_data.sh
+++ b/.platform/hooks/postdeploy/01_setup_data.sh
@@ -19,6 +19,11 @@ python manage.py migrate --noinput >> $LOG_FILE 2>&1
 
 echo "$(date): Migrations complete" >> $LOG_FILE
 
+# Collect static files (fast, ensures UI works after deployment)
+python manage.py collectstatic --noinput >> $LOG_FILE 2>&1
+
+echo "$(date): Static files collected" >> $LOG_FILE
+
 # Only run community setup once (marker file approach to avoid DB queries)
 # This avoids overhead on frequent deployments
 if [ ! -f "$SETUP_MARKER" ]; then


### PR DESCRIPTION
- Add collectstatic to post-deploy hook after migrations
- Ensures static files are collected after app is in /var/app/current/
- Prevents UI breaking after immutable deployments
- Fast operation (~2 seconds), won't slow down deployments

This fixes the issue where static files disappeared after deployment, causing the UI to break while HTML still loaded.